### PR TITLE
Auto rate limiting enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Posterous.config = {
 ## A note on rate limits ##
 
 By default the gem will wait one second per api request. However, if you have a whitelisted 
-token, you can pass ```:limit => false``` in Posterous.config like so:
+token, you can pass ```'limit' => false``` in Posterous.config like so:
 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -23,7 +23,22 @@ Posterous.config = {
   'api_token' => '<api_token>'
 }
 ```
-    
+
+## A note on rate limits ##
+
+By default the gem will wait one second per api request. However, if you have a whitelisted 
+token, you can pass ```:limit => false``` in Posterous.config like so:
+
+
+```ruby
+Posterous.config = {
+  'username'  => '<username>',
+  'password'  => '<password>',
+  'api_token' => '<api_token>'
+  'limit'     => false
+}
+```
+
 ## Elsewhere ##
     
 ```ruby

--- a/lib/posterous/connection.rb
+++ b/lib/posterous/connection.rb
@@ -29,12 +29,24 @@ module Posterous
       nil
     end
 
+    def wait_if_needed
+      if Posterous.config['limit'].nil?
+        limit = true
+      else
+        limit = Posterous.config['limit']
+      end
+      puts "limited" * 80 if limit 
+      sleep 1 if limit
+    end
+
     [:get, :post, :put, :delete].each do |verb|
       define_method verb do |path, *args|
 
         params = args.last || {}
 
         puts "POSTEROUS :: #{verb.to_s.upcase} #{path} #{params}\n\n" if ENV['POSTEROUS_DEBUG']
+
+        wait_if_needed
 
         response  = http.send(verb, "#{Posterous::BASE_API_URL}#{path}", 
                       default_options.merge!(:params => default_params.merge!(params)))

--- a/lib/posterous/connection.rb
+++ b/lib/posterous/connection.rb
@@ -35,7 +35,6 @@ module Posterous
       else
         limit = Posterous.config['limit']
       end
-      puts "limited" * 80 if limit 
       sleep 1 if limit
     end
 

--- a/lib/posterous/version.rb
+++ b/lib/posterous/version.rb
@@ -1,3 +1,3 @@
 module Posterous
-  VERSION = "0.2.7"
+  VERSION = "0.2.8"
 end


### PR DESCRIPTION
- Commands like Site.find(3793682).posts.create(:title => "asd", :body
  => "asd") were getting rate limited since they fetched more than once
  a second to construct the request
  - By default all requests will wait 1 second before continuing
  - One can pass 'limit' => false in config to bypass this (for
    whitelisted users)
